### PR TITLE
Adding flag for enabling PDF/UA Accessibility

### DIFF
--- a/src/main/java/com/openhtmltopdf/cli/App.java
+++ b/src/main/java/com/openhtmltopdf/cli/App.java
@@ -64,6 +64,12 @@ public class App
         )
         boolean block;
 
+        @Option(
+            names = { "--accessible", "-a"},
+            description = "Force PDF/UA Conformance"
+        )
+        boolean accessible;
+
         @Override
         public Integer call() throws Exception {
             if (quiet && !verbose) {
@@ -93,6 +99,11 @@ public class App
                     builder.withW3cDocument(doc, input.getAbsoluteFile().toURI().toURL().toExternalForm());
                 } else {
                     builder.withFile(input);
+                }
+
+                if (accessible) {
+                    builder.usePdfUaAccessbility(true);
+                    builder.usePdfAConformance(PdfRendererBuilder.PdfAConformance.PDFA_3_U);
                 }
 
                 builder.toStream(os);


### PR DESCRIPTION
This is just a simple change which adds the flags `-a`, `--accessible`.  These flags tell the builder to enable PDF/UA Accessibility and PDF/A conformance.

Very open to suggestions!  This minimally took care of my need to generate PDF/UA compliant PDFs, but could potentially be improved if necessary.

Thanks!